### PR TITLE
Add optional start time

### DIFF
--- a/contracts/cw-blotto/schema/cw-blotto.json
+++ b/contracts/cw-blotto/schema/cw-blotto.json
@@ -127,6 +127,17 @@
           "denom": {
             "description": "The denom used for staking in this contract",
             "type": "string"
+          },
+          "start_time": {
+            "description": "The optional start time for the game (requires nanoseconds)",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Timestamp"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "additionalProperties": false

--- a/contracts/cw-blotto/src/contract.rs
+++ b/contracts/cw-blotto/src/contract.rs
@@ -36,6 +36,8 @@ pub struct InstantiateMsgData {
     pub battle_duration: Timestamp,
     /// The denom used for staking in this contract
     pub denom: String,
+    /// The optional start time for the game (requires nanoseconds)
+    pub start_time: Option<Timestamp>,
 }
 
 /// The struct representing this contract, holding all contract state.
@@ -115,6 +117,24 @@ impl BlottoContract<'_> {
             });
         }
 
+        // Default the game phase to not started
+        let mut phase: GamePhase = GamePhase::NotStarted;
+
+        // Check if the start_time is in the past
+        if let Some(start_time) = data.start_time {
+            if start_time.seconds() <= ctx.env.block.time.seconds() {
+                return Err(ContractError::InvalidStartTime {
+                    now: ctx.env.block.time.seconds(),
+                    start_time: start_time.seconds(),
+                });
+            }
+        } else {
+            phase = GamePhase::Open;
+        }
+
+        // Set the game phase
+        self.phase.save(ctx.deps.storage, &phase)?;
+
         // Initialize armies and set their totals to zero
         let mut i = 0;
         for army in data.armies {
@@ -159,16 +179,11 @@ impl BlottoContract<'_> {
             )?;
         }
 
-        // TODO support setting an optional start time
-        // Set gamephase to open
-        self.phase.save(ctx.deps.storage, &GamePhase::Open)?;
-
         // Save config
         self.config.save(
             ctx.deps.storage,
             &Config {
-                // TODO make start time an options
-                start: ctx.env.block.time,
+                start: data.start_time.unwrap_or(ctx.env.block.time),
                 battle_duration: data.battle_duration,
                 denom: data.denom,
             },
@@ -189,9 +204,21 @@ impl BlottoContract<'_> {
         // Load Config
         let config = self.config.load(ctx.deps.storage)?;
 
-        // Check game phase is open
-        if self.phase.load(ctx.deps.storage)? != GamePhase::Open {
-            return Err(ContractError::NotOpen {});
+        // Check if the game is open
+        match self.phase.load(ctx.deps.storage)? {
+            GamePhase::NotStarted => {
+                // Check if the start_time is in the past
+                if config.start.seconds() <= ctx.env.block.time.seconds() {
+                    // Update the game phase
+                    self.phase.save(ctx.deps.storage, &GamePhase::Open)?;
+                } else {
+                    return Err(ContractError::NotOpen {});
+                }
+            }
+            GamePhase::Closed => {
+                return Err(ContractError::NotOpen {});
+            }
+            GamePhase::Open => {}
         }
 
         // Validate proper denom was sent and get amount

--- a/contracts/cw-blotto/src/error.rs
+++ b/contracts/cw-blotto/src/error.rs
@@ -56,6 +56,6 @@ pub enum ContractError {
     #[error("{0}")]
     PaymentError(#[from] PaymentError),
 
-    #[error("Start time must be in the future (in nanos); current timestamp: {now}, got timestamp: {start_time}")]
+    #[error("Start time must be in the future; current block timestamp (in seconds): {now}, received start timestamp (in seconds): {start_time}")]
     InvalidStartTime { now: u64, start_time: u64 },
 }

--- a/contracts/cw-blotto/src/error.rs
+++ b/contracts/cw-blotto/src/error.rs
@@ -55,4 +55,7 @@ pub enum ContractError {
 
     #[error("{0}")]
     PaymentError(#[from] PaymentError),
+
+    #[error("Start time must be in the future (in nanos); current timestamp: {now}, got timestamp: {start_time}")]
+    InvalidStartTime { now: u64, start_time: u64 },
 }


### PR DESCRIPTION
Closes #2 

This PR allows optional start times to be provided during the contract's instantiation (if no start time is provided, it defaults to the current block time). Additionally, when a user attempts to stake with the contract, the start time must be passed or an error will be thrown. If the start time has passed, the contract's phase will update to open.

This PR also includes 2 new tests:
- ensure a contract cannot be instantiated in the past
- ensure a contract instantiated in the future cannot be staked with until the start time has passed

All previously existing tests instantiate the contract with no start time, so they default to the current block time. These previous tests ensure that the contract instantiated is immediately open & can allow for staking.