### PR TITLE
CW CI

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -21,6 +21,7 @@ jobs:
 
   # Check formatting with rustfmt
   formatting:
+    name: Formatting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +37,7 @@ jobs:
     defaults:
       run:
         working-directory: contracts/cw-blotto
-    name: Lints
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -1,0 +1,48 @@
+on: [push, pull_request]
+
+name: Basic
+
+jobs:
+  test:
+    defaults:
+      run:
+        working-directory: contracts/cw-blotto
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-unknown-unknown
+      - name: cargo unit-test
+        run: cargo unit-test --locked
+        env:
+          RUST_BACKTRACE: 1
+
+  # Check formatting with rustfmt
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Ensure rustfmt is installed and setup problem matcher
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt
+      - name: rustfmt
+        uses: actions-rust-lang/rustfmt@v1
+        with:
+          manifest-path: contracts/cw-blotto/Cargo.toml
+  lints:
+    defaults:
+      run:
+        working-directory: contracts/cw-blotto
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy
+      - name: cargo clippy
+        run: cargo clippy -- -D warnings
+

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -18,6 +18,8 @@ jobs:
         run: cargo unit-test --locked
         env:
           RUST_BACKTRACE: 1
+      - name: Compile WASM contract
+        run: cargo wasm --lib --locked
 
   # Check formatting with rustfmt
   formatting:

--- a/contracts/cw-blotto/src/contract.rs
+++ b/contracts/cw-blotto/src/contract.rs
@@ -647,9 +647,7 @@ impl BlottoContract<'_> {
     ) -> StdResult<Option<StakingLimitInfo>> {
         let player_addr = ctx.deps.api.addr_validate(&player)?;
 
-        Ok(self
-            .staking_limits
-            .may_load(ctx.deps.storage, &player_addr)?)
+        self.staking_limits.may_load(ctx.deps.storage, &player_addr)
     }
 }
 


### PR DESCRIPTION
Implements basic CW CI for #12

https://github.com/poroburu/blotto/blob/poro-ci/.github/workflows/basic.yml
https://github.com/poroburu/blotto/actions

I think I picked the right rust targets for the jobs. Particularly `wasm32-unknown-unknown` for the unit tests.

The caching doesn't seem to be useful. Tricky to debug and more fun to fix than anything. These GH Actions may be expecting `Cargo.toml` to be in the root directory.

https://github.com/actions-rust-lang/setup-rust-toolchain
Used these rust GH Actions. `action-rs` is deprecated, and this uses the more current `Swatinem/rust-cache` and `dtolnay/rust-toolchain` actions.